### PR TITLE
Migrate to pendulum > 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ repository = "https://github.com/thebigmunch/tbm-utils"
 homepage = "https://github.com/thebigmunch/tbm-utils"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 
 attrs = ">=18.2,<19.4"
-pendulum = ">=2.0,<=3.0,!=2.0.5,!=2.1.0"  # Work around https://github.com/sdispater/pendulum/issues/454
+pendulum = ">=3"
 pprintpp = "0.*"
 wrapt = "^1.0"
 
@@ -33,7 +33,7 @@ flake8-import-order-tbm = { version = "^1.0", optional = true }
 furo = { version = "*", optional = true, allow-prereleases = true }
 myst-parser = { version = ">=0.12", optional = true }
 nox = { version = "^2019", optional = true }
-pytest = { version = ">=4.0,<6.0", optional = true }
+pytest = { version = ">=8", optional = true }
 sphinx = { version = "^3.0", optional = true}
 
 [tool.poetry.extras]

--- a/src/tbm_utils/datetime.py
+++ b/src/tbm_utils/datetime.py
@@ -122,7 +122,7 @@ def datetime_string_to_time_period(
 		else:
 			end = start.end_of('year')
 
-		period = pendulum.period(start, end)
+		period = pendulum.interval(start, end)
 	elif on:
 		if (
 			not all(
@@ -142,7 +142,7 @@ def datetime_string_to_time_period(
 			tz=parsed_tz
 		)
 
-		period = pendulum.period(dt.start_of('day'), dt.end_of('day'))
+		period = pendulum.interval(dt.start_of('day'), dt.end_of('day'))
 	elif before:
 		start = DateTime.min
 
@@ -168,7 +168,7 @@ def datetime_string_to_time_period(
 		elif parsed.second is None:
 			dt = dt.start_of('minute')
 
-		period = pendulum.period(start, dt)
+		period = pendulum.interval(start, dt)
 	else:
 		end = DateTime.max
 
@@ -194,6 +194,6 @@ def datetime_string_to_time_period(
 		elif parsed.second is None:
 			dt = dt.start_of('minute')
 
-		period = pendulum.period(dt, end)
+		period = pendulum.interval(dt, end)
 
 	return period

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,35 +60,35 @@ def test_create_parser_filter_dates():
 		]
 	)
 
-	assert args.created_in == pendulum.period(
+	assert args.created_in == pendulum.interval(
 		pendulum.datetime(2019, 8, 1, tz='local'),
 		pendulum.datetime(2019, 8, 31, tz='local').end_of('day')
 	)
-	assert args.created_on == pendulum.period(
+	assert args.created_on == pendulum.interval(
 		pendulum.datetime(2019, 8, 22, tz='local').start_of('day'),
 		pendulum.datetime(2019, 8, 22, tz='local').end_of('day')
 	)
-	assert args.created_before == pendulum.period(
+	assert args.created_before == pendulum.interval(
 		pendulum.DateTime.min,
 		pendulum.datetime(2019, 8, 22, 16, tz='local')
 	)
-	assert args.created_after == pendulum.period(
+	assert args.created_after == pendulum.interval(
 		pendulum.datetime(2019, 8, 22, 16, tz='local'),
 		pendulum.DateTime.max
 	)
-	assert args.modified_in == pendulum.period(
+	assert args.modified_in == pendulum.interval(
 		pendulum.datetime(2019, 8, 1, tz='local'),
 		pendulum.datetime(2019, 8, 31, tz='local').end_of('day')
 	)
-	assert args.modified_on == pendulum.period(
+	assert args.modified_on == pendulum.interval(
 		pendulum.datetime(2019, 8, 22, tz='local').start_of('day'),
 		pendulum.datetime(2019, 8, 22, tz='local').end_of('day')
 	)
-	assert args.modified_before == pendulum.period(
+	assert args.modified_before == pendulum.interval(
 		pendulum.DateTime.min,
 		pendulum.datetime(2019, 8, 22, 16, tz='local')
 	)
-	assert args.modified_after == pendulum.period(
+	assert args.modified_after == pendulum.interval(
 		pendulum.datetime(2019, 8, 22, 16, tz='local'),
 		pendulum.DateTime.max
 	)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -2,7 +2,7 @@ import pytest
 from pendulum import (
 	DateTime,
 	datetime,
-	period,
+	interval,
 	today,
 	yesterday
 )
@@ -48,21 +48,21 @@ def test_datetime_string_to_time_period_unsupported_datetime_string(dt_string):
 	[
 		(
 			'2019',
-			period(
+			interval(
 				datetime(2019, 1, 1, tz='local').start_of('year'),
 				datetime(2019, 12, 31, tz='local').end_of('year')
 			)
 		),
 		(
 			'2019-08',
-			period(
+			interval(
 				datetime(2019, 8, 1, tz='local').start_of('month'),
 				datetime(2019, 8, 31, tz='local').end_of('month')
 			)
 		),
 		(
 			'201908',
-			period(
+			interval(
 				datetime(2019, 8, 1, tz='local').start_of('month'),
 				datetime(2019, 8, 31, tz='local').end_of('month')
 			)
@@ -92,28 +92,28 @@ def test_datetime_string_to_time_period_in_unsupported_datetime_string(dt_string
 	[
 		(
 			'today',
-			period(
+			interval(
 				today(),
 				today().end_of('day')
 			)
 		),
 		(
 			'yesterday',
-			period(
+			interval(
 				yesterday(),
 				yesterday().end_of('day')
 			)
 		),
 		(
 			'2019-08-22',
-			period(
+			interval(
 				datetime(2019, 8, 22, tz='local').start_of('day'),
 				datetime(2019, 8, 22, tz='local').end_of('day')
 			)
 		),
 		(
 			'20190822',
-			period(
+			interval(
 				datetime(2019, 8, 22, tz='local').start_of('day'),
 				datetime(2019, 8, 22, tz='local').end_of('day')
 			)
@@ -141,140 +141,140 @@ def test_datetime_string_to_time_period_on_unsupported_datetime_string(dt_string
 	[
 		(
 			'today',
-			period(
+			interval(
 				DateTime.min,
 				today()
 			)
 		),
 		(
 			'yesterday',
-			period(
+			interval(
 				DateTime.min,
 				yesterday()
 			)
 		),
 		(
 			'2019',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 1, 1, tz='local')
 			)
 		),
 		(
 			'2019-08',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 1, tz='local')
 			)
 		),
 		(
 			'201908',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 1, tz='local')
 			)
 		),
 		(
 			'2019-08-22',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, tz='local')
 			)
 		),
 		(
 			'20190822',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, tz='local')
 			)
 		),
 		(
 			'2019-08-22T16',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz='local')
 			)
 		),
 		(
 			'2019-08-22T16:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz='local')
 			)
 		),
 		(
 			'2019-08-22T16:00:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz='local')
 			)
 		),
 		(
 			'2019-08-22 16:00:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz='local')
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(-4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04:00',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(-4 * 3600))
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04:30',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((4 * 3600) + (30 * 60)))
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04:30',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((4 * 3600) + (30 * 60)))
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04:30',
-			period(
+			interval(
 				DateTime.min,
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((-4 * 3600) - (30 * 60)))
 			)
@@ -290,140 +290,140 @@ def test_datetime_string_to_time_period_before(dt_string, expected):
 	[
 		(
 			'today',
-			period(
+			interval(
 				today().end_of('day'),
 				DateTime.max
 			)
 		),
 		(
 			'yesterday',
-			period(
+			interval(
 				yesterday().end_of('day'),
 				DateTime.max
 			)
 		),
 		(
 			'2019',
-			period(
+			interval(
 				datetime(2019, 12, 31, tz='local').end_of('year'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08',
-			period(
+			interval(
 				datetime(2019, 8, 31, tz='local').end_of('month'),
 				DateTime.max
 			)
 		),
 		(
 			'201908',
-			period(
+			interval(
 				datetime(2019, 8, 31, tz='local').end_of('month'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22',
-			period(
+			interval(
 				datetime(2019, 8, 22, tz='local').end_of('day'),
 				DateTime.max
 			)
 		),
 		(
 			'20190822',
-			period(
+			interval(
 				datetime(2019, 8, 22, tz='local').end_of('day'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz='local'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz='local'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz='local'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22 16:00:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz='local'),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(-4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04:00',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone(-4 * 3600)),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00 04:30',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((4 * 3600) + (30 * 60))),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00+04:30',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((4 * 3600) + (30 * 60))),
 				DateTime.max
 			)
 		),
 		(
 			'2019-08-22T16:00:00-04:30',
-			period(
+			interval(
 				datetime(2019, 8, 22, 16, tz=fixed_timezone((-4 * 3600) - (30 * 60))),
 				DateTime.max
 			)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -26,22 +26,22 @@ TEST_FILEPATHS = list(TEST_DIR.iterdir())
 THIS = pendulum.now()
 LAST = THIS.start_of('year').previous(pendulum.MONDAY)
 
-THIS_YEAR = pendulum.period(
+THIS_YEAR = pendulum.interval(
 	THIS.start_of('year'),
 	THIS.end_of('year'),
 )
 
-TODAY = pendulum.period(
+TODAY = pendulum.interval(
 	THIS.start_of('day'),
 	THIS.end_of('day'),
 )
 
-YESTERDAY = pendulum.period(
+YESTERDAY = pendulum.interval(
 	THIS.subtract(days=1).start_of('day'),
 	THIS.subtract(days=1).end_of('day'),
 )
 
-LAST_YEAR = pendulum.period(
+LAST_YEAR = pendulum.interval(
 	LAST.start_of('year'),
 	LAST.end_of('year'),
 )
@@ -83,7 +83,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			creation_dates=[
-				pendulum.period(
+				pendulum.interval(
 					pendulum.DateTime.min,
 					THIS.start_of('day'),
 				)
@@ -95,7 +95,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			creation_dates=[
-				pendulum.period(
+				pendulum.interval(
 					pendulum.DateTime.min,
 					THIS.add(days=1),
 				)
@@ -107,7 +107,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			creation_dates=[
-				pendulum.period(
+				pendulum.interval(
 					THIS.add(days=1),
 					pendulum.DateTime.max,
 				)
@@ -119,7 +119,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			creation_dates=[
-				pendulum.period(
+				pendulum.interval(
 					THIS.start_of('day'),
 					pendulum.DateTime.max,
 				)
@@ -159,7 +159,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			modification_dates=[
-				pendulum.period(
+				pendulum.interval(
 					pendulum.DateTime.min,
 					THIS.start_of('day'),
 				)
@@ -171,7 +171,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			modification_dates=[
-				pendulum.period(
+				pendulum.interval(
 					pendulum.DateTime.min,
 					THIS.add(days=1),
 				)
@@ -183,7 +183,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			modification_dates=[
-				pendulum.period(
+				pendulum.interval(
 					THIS.add(days=1),
 					pendulum.DateTime.max,
 				)
@@ -195,7 +195,7 @@ def test_filter_filepaths_by_dates():
 		filter_filepaths_by_dates(
 			TEST_FILEPATHS,
 			modification_dates=[
-				pendulum.period(
+				pendulum.interval(
 					THIS.start_of('day'),
 					pendulum.DateTime.max,
 				)


### PR DESCRIPTION
Most distributions are shipping `pendulum` > 3 nowadays. Thus, the current constraint blocks `tbm-utils` from build and because of that all consumers as well.

This is one commit to make it simpler for interested parties to grab the patch as `tbm-utils` doesn't seem to be maintained.